### PR TITLE
Fix guzzlehttp/psr7 >= 2.0

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -11,7 +11,7 @@ use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Uri;
-use function GuzzleHttp\Psr7\uri_for;
+use GuzzleHttp\Psr7\Utils;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
@@ -133,7 +133,11 @@ class Client
      */
     public function newRequest(string $method, $uri, array $headers = [], $body = null): RequestInterface
     {
-        $uri = uri_for($uri);
+        if (method_exists(Utils::class, 'uriFor')) {
+            $uri = Utils::uriFor($uri);
+        } else {
+            $uri = \GuzzleHttp\Psr7\uri_for($uri);
+        }
         $path = rtrim($this->baseUrl->getPath() . $uri->getPath(), '/');
 
         $uri = $uri

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -10,7 +10,7 @@ use Every8d\Exception\UnexpectedStatusCodeException;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
-use function GuzzleHttp\Psr7\uri_for;
+use GuzzleHttp\Psr7\Utils;
 use PHPUnit\Framework\TestCase;
 
 class ClientTest extends TestCase
@@ -107,8 +107,12 @@ class ClientTest extends TestCase
     {
         $client = $this->createClient();
         $client->setBaseUrl($baseUri);
+        if (method_exists(Utils::class, 'uriFor')) {
+            $expected = Utils::uriFor($exceptedUri);
+        } else {
+            $expected = \GuzzleHttp\Psr7\uri_for($exceptedUri);
+        }
 
-        $expected = uri_for($exceptedUri);
         $actual = $client->newFormRequest($actualUri)->getUri();
 
         $this->assertEquals($expected, $actual);


### PR DESCRIPTION
Fix psr7 >= v2.0

https://github.com/guzzle/psr7/tree/2.0.0#upgrading-from-function-api

the `uri_for` method already moved to [Utils::uriFor](https://github.com/guzzle/psr7/blob/2.0.0/src/Utils.php#L400)